### PR TITLE
report client errors

### DIFF
--- a/opendata_transport/__init__.py
+++ b/opendata_transport/__init__.py
@@ -33,14 +33,18 @@ class OpendataTransport(object):
 
         try:
             with async_timeout.timeout(5, loop=self._loop):
-                response = await self._session.get(url)
+                response = await self._session.get(url, raise_for_status=True)
 
             _LOGGER.debug(
                 "Response from transport.opendata.ch: %s", response.status)
             data = await response.json()
             _LOGGER.debug(data)
-        except (asyncio.TimeoutError, aiohttp.ClientError):
+        except (asyncio.TimeoutError):
             _LOGGER.error("Can not load data from transport.opendata.ch")
+            raise exceptions.OpendataTransportConnectionError()
+        except (aiohttp.ClientError) as aiohttpClientError:
+            _LOGGER.error("Response from transport.opendata.ch: %s" \
+                                                 , aiohttpClientError)
             raise exceptions.OpendataTransportConnectionError()
 
         try:

--- a/opendata_transport/__init__.py
+++ b/opendata_transport/__init__.py
@@ -43,8 +43,8 @@ class OpendataTransport(object):
             _LOGGER.error("Can not load data from transport.opendata.ch")
             raise exceptions.OpendataTransportConnectionError()
         except (aiohttp.ClientError) as aiohttpClientError:
-            _LOGGER.error("Response from transport.opendata.ch: %s" \
-                                                 , aiohttpClientError)
+            _LOGGER.error("Response from transport.opendata.ch: %s",
+                          aiohttpClientError)
             raise exceptions.OpendataTransportConnectionError()
 
         try:


### PR DESCRIPTION
report client errors so that exceptions like ratelimiting (transport.opendata.ch proxies requests to timetable.search.ch which limits number f daily requests to 1000 as in sep'18 but can change)

fixes fabaff/python-opendata-transport#3