### PR TITLE
Don't use async timeout

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 
 [packages]
 aiohttp = "*"
-async-timeout = "*"
 
 [requires]
 python_version = "3.7"

--- a/opendata_transport/__init__.py
+++ b/opendata_transport/__init__.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 
 import aiohttp
-import async_timeout
 import urllib.parse
 
 from . import exceptions
@@ -64,8 +63,7 @@ class OpendataTransportStationboard(OpendataTransportBase):
         url = self.get_url("stationboard", params)
 
         try:
-            with async_timeout.timeout(5, loop=self._loop):
-                response = await self._session.get(url, raise_for_status=True)
+            response = await self._session.get(url, raise_for_status=True)
 
             _LOGGER.debug("Response from transport.opendata.ch: %s", response.status)
             data = await response.json()
@@ -134,8 +132,7 @@ class OpendataTransport(OpendataTransportBase):
         )
 
         try:
-            with async_timeout.timeout(5, loop=self._loop):
-                response = await self._session.get(url, raise_for_status=True)
+            response = await self._session.get(url, raise_for_status=True)
 
             _LOGGER.debug("Response from transport.opendata.ch: %s", response.status)
             data = await response.json()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     license="MIT",
     install_requires=[
         "aiohttp>=3.7.4,<4",
-        "async_timeout<4",
         "urllib3",
     ],
     packages=find_packages(),


### PR DESCRIPTION
There is no need to use async timeout as the aiohttp ClientSession
has its own timeout capability. In fact, a timeout of 5s seems to
be problematic in a HomeAssistant installation at startup where
many asynchronous operation happens within a short time. Is the CPU
does not get around to check opendata_transport integration in time
the integration fails with:
Can not load data from transport.opendata.ch.