### PR TITLE
Add KeyError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+20231213 - 0.4.1
+----------------
+
+- Add KeyError exception (thanks @miaucl)
+
 20231120 - 0.4.0
 ----------------
 

--- a/opendata_transport/__init__.py
+++ b/opendata_transport/__init__.py
@@ -89,7 +89,7 @@ class OpendataTransportLocation(OpendataTransportBase):
         try:
             for station in data["stations"]:
                 self.locations.append(self.get_station(station))
-        except (TypeError, IndexError):
+        except (KeyError, TypeError, IndexError):
             raise exceptions.OpendataTransportError()
 
 
@@ -174,7 +174,7 @@ class OpendataTransportStationboard(OpendataTransportBase):
         try:
             for journey in data["stationboard"]:
                 self.journeys.append(self.get_journey(journey))
-        except (TypeError, IndexError):
+        except (KeyError, TypeError, IndexError):
             raise exceptions.OpendataTransportError()
 
     async def async_get_data(self):
@@ -309,5 +309,5 @@ class OpendataTransport(OpendataTransportBase):
             for connection in data["connections"]:
                 self.connections[index] = self.get_connection(connection)
                 index = index + 1
-        except (TypeError, IndexError):
+        except (KeyError, TypeError, IndexError):
             raise exceptions.OpendataTransportError()


### PR DESCRIPTION
I stumbled across a `KeyError` raised by the library, which should be caught instead, alike the `TypeError` and `IndexError`.