### PR TITLE
Add line number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,11 @@
 Changes
 =======
 
-20231213 - 0.4.1
+20240113 - 0.5.0
 ----------------
 
 - Add KeyError exception (thanks @miaucl)
+- Add line numbers (thanks @polgarc)
 
 20231120 - 0.4.0
 ----------------

--- a/opendata_transport/__init__.py
+++ b/opendata_transport/__init__.py
@@ -252,7 +252,9 @@ class OpendataTransport(OpendataTransportBase):
         connection_info["number"] = ""
         for section in connection["sections"]:
             if section["journey"] is not None:
-                connection_info["number"] = section["journey"]["name"]
+                journey = section["journey"]
+                connection_info["number"] = journey["name"]
+                connection_info["line"] = ''.join(filter(None, [journey["category"], journey["number"]]))
                 break
 
         connection_info["platform"] = connection["from"]["platform"]

--- a/opendata_transport/__init__.py
+++ b/opendata_transport/__init__.py
@@ -254,7 +254,9 @@ class OpendataTransport(OpendataTransportBase):
             if section["journey"] is not None:
                 journey = section["journey"]
                 connection_info["number"] = journey["name"]
-                connection_info["line"] = ''.join(filter(None, [journey["category"], journey["number"]]))
+                connection_info["line"] = "".join(
+                    filter(None, [journey["category"], journey["number"]])
+                )
                 break
 
         connection_info["platform"] = connection["from"]["platform"]


### PR DESCRIPTION
Add line number, as the existing `name` field is not really that informative.

Extract from the output of the  `example.py`:

```
http://transport.opendata.ch/v1/connections?from=Z%C3%BCrich%2C+Blumenfeldstrasse&to=Z%C3%BCrich+Oerlikon%2C+Bahnhof&limit=4&page=0&isArrivalTime=0&direct=0&sleeper=0&couchette=0&bike=0
Train connections: Zürich, Blumenfeldstrasse -> Zürich Oerlikon, Bahnhof
{0: {'departure': '2024-01-13T15:14:00+0100', 'duration': '00d00:11:00', 'delay': 0, 'transfers': 0, 'number': '012768', 'line': 'B61', 'platform': None}, 1: {'departure': '2024-01-13T15:29:00+0100', 'duration': '00d00:11:00', 'delay': 0, 'transfers': 0, 'number': '013090', 'line': 'B61', 'platform': None}, 2: {'departure': '2024-01-13T15:35:00+0100', 'duration': '00d00:15:00', 'delay': None, 'transfers': 0, 'number': '018659', 'line': 'S6', 'platform': None}, 3: {'departure': '2024-01-13T15:44:00+0100', 'duration': '00d00:11:00', 'delay': None, 'transfers': 0, 'number': '013439', 'line': 'B61', 'platform': None}}
{'departure': '2024-01-13T15:14:00+0100', 'duration': '00d00:11:00', 'delay': 0, 'transfers': 0, 'number': '012768', 'line': 'B61', 'platform': None}
```

`'line': 'B61'` means bus line 61, which is more informative than `'number': '013439'`.

Other examples are
- `T10` (tram)
- `IR36` (train)
- `S16` (train)